### PR TITLE
fix issue where liquid tag is invoked stead of written as code

### DIFF
--- a/_posts/2021-05-09-Embed Mermaid in Jekyll without plugin.md
+++ b/_posts/2021-05-09-Embed Mermaid in Jekyll without plugin.md
@@ -31,11 +31,13 @@ Create a file `mermaid.html` in `_include` directory with the following content:
 
 Add the following content to the end of file `footer-scripts.html` in directory `_include`.
 
+{% raw %}
 ```html
 {% if page.mermaid %} 
   {% include mermaid.html %} 
 {% endif %}
 ```
+{% endraw %}
 
 ## Enable mermaid rendering
 


### PR DESCRIPTION
If you go to https://jackgruber.github.io/2021-05-09-Embed-Mermaid-in-Jekyll-without-plugin/ it is shown as:

Add the following content to the end of file footer-scripts.html in directory _include.
```
  <script src="https://unpkg.com/mermaid@8.9.3/dist/mermaid.min.js"></script>
<script>
  $(document).ready(function () {
    mermaid.initialize({
      startOnLoad:true,
      theme: "default",
    });
    window.mermaid.init(undefined, document.querySelectorAll('.language-mermaid'));
  });
</script>
 ```

but should be:

Add the following content to the end of file footer-scripts.html in directory _include.
```
{% if page.mermaid %} 
  {% include mermaid.html %} 
{% endif %}
```

Root cause is that the liquid tag is getting rendered so what ever is in mermaid.html is placed there instead of the snippet you wanted from `footer-scripts.html`.

I attempted to resolve this by using the raw liquid tag as suggested by https://stackoverflow.com/questions/49602007/escaping-rendering-liquid-template-in-jekyll-markdown but haven't.

PS: Thanks for the post. I came across it trying to figure out how to get mermaid to work with beautiful jekyll.